### PR TITLE
Update pebble-assist.h

### DIFF
--- a/pebble-assist.h
+++ b/pebble-assist.h
@@ -31,6 +31,9 @@ THE SOFTWARE.
 
 #pragma once
 
+// Pointer Logging
+static bool SHOW_POINTERS = false;
+
 // Missing Constants
 
 #ifndef MENU_CELL_BASIC_CELL_HEIGHT
@@ -57,22 +60,22 @@ THE SOFTWARE.
 #define ERROR(...) app_log(APP_LOG_LEVEL_ERROR, __FILE__, __LINE__, __VA_ARGS__)
 
 // Window Helpers
-#define window_destroy_safe(window) if (NULL != window) { window_destroy(window); window = NULL; }
+#define window_destroy_safe(window) if (NULL != window) { if(SHOW_POINTERS){ DEBUG("Window Destroy Safe: %p", window); } window_destroy(window); window = NULL; }
 
 // Number Window Helpers
-#define number_window_destroy_safe(window) if (NULL != window) { number_window_destroy(window); window = NULL; }
+#define number_window_destroy_safe(window) if (NULL != window) { if(SHOW_POINTERS){ DEBUG("Number Window Destroy Safe: %p", window); } number_window_destroy(window); window = NULL; }
 
 // Layer Helpers
 #define layer_create_fullscreen(window) layer_create(layer_get_bounds(window_get_root_layer(window)));
 #define layer_add_to_window(layer, window) layer_add_child(window_get_root_layer(window), layer)
 #define layer_show(layer) layer_set_hidden(layer, false)
 #define layer_hide(layer) layer_set_hidden(layer, true)
-#define layer_destroy_safe(layer) if (NULL != layer) { layer_destroy(layer); layer = NULL; }
+#define layer_destroy_safe(layer) if (NULL != layer) { if(SHOW_POINTERS){ DEBUG("Layer Destroy Safe: %p", layer); } layer_destroy(layer); layer = NULL; }
 
 // Scroll Layer Helpers
 #define scroll_layer_create_fullscreeen(window) scroll_layer_create(layer_get_bounds(window_get_root_layer(window)))
 #define scroll_layer_add_to_window(layer, window) layer_add_child(window_get_root_layer(window), scroll_layer_get_layer(layer))
-#define scroll_layer_destroy_safe(layer) if (NULL != layer) { scroll_layer_destroy(layer); layer = NULL; }
+#define scroll_layer_destroy_safe(layer) if (NULL != layer) { if(SHOW_POINTERS){ DEBUG("Scroll Layer Destroy Safe: %p", layer); } scroll_layer_destroy(layer); layer = NULL; }
 
 // Text Layer Helpers
 #define text_layer_create_fullscreen(window) text_layer_create(layer_get_bounds(window_get_root_layer(window)));
@@ -80,36 +83,39 @@ THE SOFTWARE.
 #define text_layer_set_system_font(layer, font) text_layer_set_font(layer, fonts_get_system_font(font))
 #define text_layer_set_colours(layer, foreground, background) text_layer_set_text_color(layer, foreground); text_layer_set_background_color(layer, background)
 #define text_layer_set_colors(layer, foreground, background) text_layer_set_text_color(layer, foreground); text_layer_set_background_color(layer, background)
-#define text_layer_destroy_safe(layer) if (NULL != layer) { text_layer_destroy(layer); layer = NULL; }
+#define text_layer_destroy_safe(layer) if (NULL != layer) { if(SHOW_POINTERS){ DEBUG("Text Layer Destroy Safe: %p", layer); } text_layer_destroy(layer); layer = NULL; }
 
 // Bitmap Layer Helpers
 #define bitmap_layer_create_fullscreen(window) bitmap_layer_create(layer_get_bounds(window_get_root_layer(window)));
 #define bitmap_layer_add_to_window(layer, window) layer_add_child(window_get_root_layer(window), bitmap_layer_get_layer(layer))
-#define bitmap_layer_destroy_safe(layer) if (NULL != layer) { bitmap_layer_destroy(layer); layer = NULL; }
+#define bitmap_layer_destroy_safe(layer) if (NULL != layer) { if(SHOW_POINTERS){ DEBUG("Bitmap Layer Destroy Safe: %p", layer); } bitmap_layer_destroy(layer); layer = NULL; }
+
+// GBitmap
+#define gbitmap_destroy_safe(gbitmap) if (NULL != gbitmap) {if(SHOW_POINTERS){ DEBUG("GBitmap Destroy Safe: %p", gbitmap); } gbitmap_destroy(gbitmap); gbitmap = NULL; }
 
 // Inverter Layer Helpers
 #define inverter_layer_add_to_window(layer, window) layer_add_child(window_get_root_layer(window), inverter_layer_get_layer(layer))
 #define inverter_layer_create_fullscreen(layer, window) inverter_layer_create(layer_get_bounds(window_get_root_layer(window)))
-#define inverter_layer_destroy_safe(layer) if (NULL != layer) { inverter_layer_destroy(layer); layer = NULL; }
+#define inverter_layer_destroy_safe(layer) if (NULL != layer) { if(SHOW_POINTERS){ DEBUG("Inverter Layer Destroy Safe: %p", layer); } inverter_layer_destroy(layer); layer = NULL; }
 
 // Menu Layer Helpers
 #define menu_layer_create_fullscreen(window) menu_layer_create(layer_get_bounds(window_get_root_layer(window)))
 #define menu_layer_add_to_window(layer, window) layer_add_child(window_get_root_layer(window), menu_layer_get_layer(layer)); menu_layer_set_click_config_onto_window(layer, window)
 #define menu_layer_reload_data_and_mark_dirty(layer) menu_layer_reload_data(layer); layer_mark_dirty(menu_layer_get_layer(layer));
-#define menu_layer_destroy_safe(layer) if (NULL != layer) { menu_layer_destroy(layer); layer = NULL; }
+#define menu_layer_destroy_safe(layer) if (NULL != layer) { if(SHOW_POINTERS){ DEBUG("Menu Layer Destroy Safe: %p", layer); } menu_layer_destroy(layer); layer = NULL; }
 
 // Simple Menu Layer Helpers
 #define simple_menu_layer_create_fullscreen(window, sections, num_sections, callback_context) simple_menu_layer_create(layer_get_bounds(window_get_root_layer(window)), sections, num_sections, callback_context)
 #define simple_menu_layer_add_to_window(layer, window) layer_add_child(window_get_root_layer(window), simple_menu_layer_get_layer(layer))
-#define simple_menu_layer_destroy_safe(layer) if (NULL != layer) { simple_menu_layer_destroy(layer); layer = NULL; }
+#define simple_menu_layer_destroy_safe(layer) if (NULL != layer) { if(SHOW_POINTERS){ DEBUG("Simple Menu Layer Destroy Safe: %p", layer); } simple_menu_layer_destroy(layer); layer = NULL; }
 
 // Action Bar Layer Helpers
 #define action_bar_layer_create_in_window(action_bar, window) action_bar = action_bar_layer_create(); action_bar_layer_add_to_window(action_bar, window)
 #define action_bar_layer_clear_icons(action_bar) action_bar_layer_clear_icon(action_bar, BUTTON_ID_SELECT); action_bar_layer_clear_icon(action_bar, BUTTON_ID_DOWN); action_bar_layer_clear_icon(action_bar, BUTTON_ID_UP)
-#define action_bar_layer_destroy_safe(layer) if (NULL != layer) { action_bar_layer_destroy(layer); layer = NULL; }
+#define action_bar_layer_destroy_safe(layer) if (NULL != layer) { if(SHOW_POINTERS){ DEBUG("Action Bar Layer Destroy Safe: %p", layer); } action_bar_layer_destroy(layer); layer = NULL; }
 
 // Dynamic Memory Helpers
-#define free_safe(ptr) if (NULL != ptr) { free(ptr); ptr = NULL; }
+#define free_safe(ptr) if (NULL != ptr) { if(SHOW_POINTERS){ DEBUG("Free Safe: %p", ptr); } free(ptr); ptr = NULL; }
 
 // App Timer Helpers
 #define app_timer_cancel_safe(timer) if (timer != NULL) { app_timer_cancel(timer); timer = NULL; }


### PR DESCRIPTION
I have added a method for enabling and disabling pointer logging. Great to check which pointers are being destroyed by the macros. I used this to find a double free error. 

Added gbitmap_destroy_safe macro.
